### PR TITLE
fix: fix collection list parsing

### DIFF
--- a/src/interactive.go
+++ b/src/interactive.go
@@ -211,7 +211,7 @@ func getAvailableCollections(vdbName string) ([]string, error) {
 
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
-		if line != "" && !strings.HasPrefix(line, "Found") && !strings.HasPrefix(line, "Collections") {
+		if line != "" && line != "[" && line != "]" && !strings.HasPrefix(line, "Found") && !strings.HasPrefix(line, "Collections") {
 			// Extract collection name from the line
 			// Assuming format like "1. collection_name" or just "collection_name"
 			if strings.Contains(line, ". ") {
@@ -220,7 +220,7 @@ func getAvailableCollections(vdbName string) ([]string, error) {
 					collections = append(collections, strings.TrimSpace(parts[1]))
 				}
 			} else {
-				collections = append(collections, line)
+				collections = append(collections, strings.Trim(line, "\""))
 			}
 		}
 	}

--- a/src/status.go
+++ b/src/status.go
@@ -105,14 +105,14 @@ func showStatus(vdbName string) error {
 			var collections []string
 			for _, line := range lines {
 				line = strings.TrimSpace(line)
-				if line != "" && !strings.HasPrefix(line, "Found") && !strings.HasPrefix(line, "Collections") {
+				if line != "" && line != "[" && line != "]" && !strings.HasPrefix(line, "Found") && !strings.HasPrefix(line, "Collections") {
 					if strings.Contains(line, ". ") {
 						parts := strings.SplitN(line, ". ", 2)
 						if len(parts) > 1 {
 							collections = append(collections, strings.TrimSpace(parts[1]))
 						}
 					} else {
-						collections = append(collections, line)
+						collections = append(collections, strings.Trim(line, "\""))
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #4 

Fixes the parsing of the collections list in `maestro status` and any call where the user is prompted to choose the collection from the list of available collections (eg `maestro query "hello"`)